### PR TITLE
spec: make libattr-devel a Build dependency for everything Lustre

### DIFF
--- a/robinhood.spec.in
+++ b/robinhood.spec.in
@@ -25,7 +25,11 @@
 # macro for defining dependencies
 
 %define pkg_dependencies       \
+%if %{with lhsm}               \
+BuildRequires: libattr-devel   \
+%endif                         \
 %if %{with lustre}             \
+BuildRequires: libattr-devel   \
 %if %{defined lpackage}        \
 Requires: %{lpackage} >= %{lversion}         \
 BuildRequires: %{lpackage} >= %{lversion}    \
@@ -101,6 +105,7 @@ This uses robinhood database to display misc. user and group stats.
 %package recov-tools
 Summary: Tools for MDS recovery.
 Group: Applications/System
+BuildRequires: libattr-devel
 
 %description recov-tools
 Tools for MDS recovery.

--- a/src/common/lustre_tools.c
+++ b/src/common/lustre_tools.c
@@ -30,7 +30,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifdef HAVE_ATTR_XATTR_H
 #include <attr/xattr.h>
+#endif
 
 #include "lustre_extended_types.h"
 


### PR DESCRIPTION
I've seen compilation failing on missing `xattr/attr.h` when `libattr-devel` is not installed. Trying to add this as a `BuildRequirement` in the spec file.

`lustre_tools.c` seems to be compiled whatever the purpose is, so added a `#ifdef` there
