### PR TITLE
Add a new configure flag: --enable-dist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,42 @@ AC_PREFIX_DEFAULT([/usr])
 
 AC_GNU_SOURCE
 
+AC_CONFIG_FILES([Makefile
+         src/Makefile
+         src/include/Makefile
+         src/common/Makefile
+         src/cfg_parsing/Makefile
+         src/list_mgr/Makefile
+         src/entry_processor/Makefile
+         src/fs_scan/Makefile
+         src/chglog_reader/Makefile
+         src/modules/Makefile
+         src/policies/Makefile
+         src/robinhood/Makefile
+         src/tools/Makefile
+         src/tests/Makefile
+         scripts/Makefile
+         scripts/robinhood.init
+         scripts/robinhood.init.sles
+         scripts/sysconfig_robinhood
+         scripts/ld.so.robinhood.conf
+         scripts/rbh_cksum.sh
+         tests/Makefile
+         tests/test_suite/Makefile
+         web_gui/Makefile
+         man/Makefile
+         robinhood.spec
+         doc/doxygen/doxygen.cfg])
+
+AC_ARG_ENABLE([dist],
+              AC_HELP_STRING([--enable-dist], [Only configure enough for make dist]),
+              [],
+              [enable_dist="no"])
+AS_IF([test "x$enable_dist" != xno], [
+AC_OUTPUT
+exit
+])
+
 # required for automake 1.12 (since fedora 18)
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
@@ -425,33 +461,6 @@ AC_SUBST(SBINDIR)
 AS_AC_EXPAND(LIBDIR, $libdir)
 AC_SUBST(LIBDIR)
 
-
-AC_CONFIG_FILES([Makefile
-         src/Makefile
-         src/include/Makefile
-         src/common/Makefile
-         src/cfg_parsing/Makefile
-         src/list_mgr/Makefile
-         src/entry_processor/Makefile
-         src/fs_scan/Makefile
-         src/chglog_reader/Makefile
-         src/modules/Makefile
-         src/policies/Makefile
-         src/robinhood/Makefile
-         src/tools/Makefile
-         src/tests/Makefile
-         scripts/Makefile
-         scripts/robinhood.init
-         scripts/robinhood.init.sles
-         scripts/sysconfig_robinhood
-         scripts/ld.so.robinhood.conf
-         scripts/rbh_cksum.sh
-         tests/Makefile
-         tests/test_suite/Makefile
-         web_gui/Makefile
-         man/Makefile
-         robinhood.spec
-         doc/doxygen/doxygen.cfg])
 AC_OUTPUT
 
 AC_MSG_NOTICE([Summary:])

--- a/configure.ac
+++ b/configure.ac
@@ -425,8 +425,6 @@ AC_SUBST(SBINDIR)
 AS_AC_EXPAND(LIBDIR, $libdir)
 AC_SUBST(LIBDIR)
 
-# for exporting to spec file
-AC_SUBST(ac_configure_args)
 
 AC_CONFIG_FILES([Makefile
          src/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,20 @@ AC_ARG_ENABLE([dist],
               AC_HELP_STRING([--enable-dist], [Only configure enough for make dist]),
               [],
               [enable_dist="no"])
-AS_IF([test "x$enable_dist" != xno], [
+
+AM_PROG_LEX
+AC_PATH_PROG(LEX_INST, $LEX)
+if test -z "$LEX_INST" -a "x$enable_dist" = xyes; then
+  AC_MSG_ERROR([lex/flex not found])
+fi
+
+AC_PROG_YACC
+AC_PATH_PROG(YACC_INST, $YACC)
+if test -z "$YACC_INST" -a "x$enable_dist" = xyes; then
+  AC_MSG_ERROR([yacc/bison not found])
+fi
+
+AS_IF([test "x$enable_dist" = xyes], [
 AC_OUTPUT
 exit
 ])
@@ -68,8 +81,6 @@ AC_PROG_CC
 m4_ifdef([AM_PROG_CC_C_O], [AM_PROG_CC_C_O])
 
 AC_C_INLINE
-AM_PROG_LEX
-AC_PROG_YACC
 
 # define everything necessary for accessing large files (64bits offset)
 AC_SYS_LARGEFILE

--- a/robinhood.spec.in
+++ b/robinhood.spec.in
@@ -68,8 +68,6 @@ for managing large file systems with millions of entries and petabytes of data.
 
 With support for: %{?with_lustre:Lustre} %{?with_backup:Backup} %{?with_shook:shook}
 
-Generated using options: @ac_configure_args@
-
 %if %{with lustre}
 # Package robinhood-lustre includes robinhood for Lustre filesystem
 # which is not compatible with robinhood-posix.
@@ -159,7 +157,7 @@ Annex tools for robinhood.
 %setup -q -n @PACKAGE@-%{version}
 
 %build
-./configure @ac_configure_args@ %{?configure_flags:configure_flags} \
+./configure %{?configure_flags:configure_flags} \
         --mandir=%{_mandir} \
         --libdir=%{_libdir}
 make %{?_smp_mflags}


### PR DESCRIPTION
This configure flag makes the script do the bare minimum so that `make
dist` will work and the `robinhood.spec.in` template will be instantiated.
In this way, we can create a `.src.rpm`. The SRPM itself defines a build
script that starts by running configure again, this time
without `--enable-dist` (i.e. do a full configure).