### PR TITLE
Fix mkdir_recurse missing character in path

### DIFF
--- a/src/common/rbh_misc.c
+++ b/src/common/rbh_misc.c
@@ -2134,7 +2134,7 @@ int mkdir_recurse(const char *full_path, mode_t mode, entry_id_t *dir_id)
         int path_len = curr - full_path;
 
         /* extract directory name */
-        rh_strncpy(path_copy, full_path, path_len);
+        rh_strncpy(path_copy, full_path, path_len+1);
         path_copy[path_len] = '\0';
 
         DisplayLog(LVL_FULL, MKDIR_TAG, "mkdir(%s)", path_copy);


### PR DESCRIPTION
Hello,
While testing the rbh_undelete command, I noticed that when restoring a file it was recursively creating directories missing the last character at each step.

Given a path /dir_a/dir_b/dir_c, currently mkdir_recurse will try to
create directories missing the last character: eg:

/dir_
/dir_a/dir_
/dir_a/dir_b/dir_

since path_copy is created by:

rh_strncpy(path_copy, fully_path, path_len), and rh_strncpy subtracts 1
from the path_len.

This commit just adds 1 to the path_len to offset this.

I'm not sure if there is a better way to resolve this, but this seemed to be sufficient.