### PR TITLE
small changes in order to get obs running

### DIFF
--- a/robinhood.spec.in
+++ b/robinhood.spec.in
@@ -38,7 +38,13 @@
 %endif
 
 # target install dir for web gui
-%define installdir_www  /var/www
+%if %{defined suse_version}
+%define installdir_www /srv/www
+%define confdir_www /apache2
+%else
+%define installdir_www /var/www
+%define confdir_www /httpd
+%endif
 
 ###### end of macro definitions #####
 
@@ -59,7 +65,7 @@ Prefix: %{_prefix}
 Release: @RELEASE@%{?config_dependant}%{?dist}
 
 Summary: Robinhood - Policy engine and reporting tool for large filesystems
-License: CeCILL-C
+License: CECILL-C
 Group: Applications/System
 Url: http://robinhood.sourceforge.net
 Source0: @PACKAGE@-%{version}.tar.gz
@@ -67,6 +73,13 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: glib2-devel >= 2.16
 BuildRequires: libattr-devel
 BuildRequires: mailx
+BuildRequires: automake
+BuildRequires: libtool
+%if %{defined suse_version}
+BuildRequires: libmysqlclient-devel
+%else
+BuildRequires: mysql-devel
+%endif
 %if %{with_systemd}
 %if %{defined suse_version}
 BuildRequires: systemd-rpm-macros
@@ -85,9 +98,9 @@ BuildRequires: %{lpackage}
 BuildRequires: libuuid-devel
 %endif
 %endif
-%if %{with mysql}
-BuildRequires: /usr/include/mysql/mysql.h
-%endif
+#%if %{with mysql}
+#BuildRequires: /usr/include/mysql/mysql.h
+#%endif
 
 %description
 Robinhood is a tool for monitoring and applying policies to file system entries.
@@ -141,7 +154,7 @@ Policy engine for POSIX filesystems.
 
 %if %{with common_rpms}
 %package adm
-Summary: admin/config helper for Robinhood PolicyEngine
+Summary: Admin/Config helper for Robinhood PolicyEngine
 Group: Applications/System
 Release: @RELEASE@.noarch
 
@@ -197,6 +210,11 @@ Annex tools for robinhood.
 
 
 %build
+libtoolize --force --copy
+autoheader
+aclocal
+automake --add-missing --copy $am_opt
+autoconf
 ./configure %{lswitch} %{?configure_flags} --mandir=%{_mandir} --libdir=%{_libdir}
 make %{?_smp_mflags}
 
@@ -221,7 +239,9 @@ install -m 644 doc/templates/example.conf $RPM_BUILD_ROOT/%{_sysconfdir}/robinho
 install -m 644 doc/templates/basic.conf $RPM_BUILD_ROOT/%{_sysconfdir}/robinhood.d/templates/
 
 mkdir $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig
+%if (0%{?fedora} || 0%{?rhel})
 install -m 644 scripts/sysconfig_robinhood $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/robinhood
+%endif
 
 install -m 644 scripts/ld.so.robinhood.conf $RPM_BUILD_ROOT/%{_sysconfdir}/ld.so.conf.d/robinhood.conf
 
@@ -229,8 +249,8 @@ install -m 644 scripts/ld.so.robinhood.conf $RPM_BUILD_ROOT/%{_sysconfdir}/ld.so
 mkdir -p $RPM_BUILD_ROOT/%{installdir_www}/robinhood
 cp -r web_gui/gui_v3/* $RPM_BUILD_ROOT/%{installdir_www}/robinhood/.
 cp    web_gui/gui_v3/api/.htaccess $RPM_BUILD_ROOT/%{installdir_www}/robinhood/api/.
-mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/
-install -m 644 web_gui/robinhood.conf $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf.d/.
+mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/%{confdir_www}/conf.d/
+install -m 644 web_gui/robinhood.conf $RPM_BUILD_ROOT/%{_sysconfdir}/%{confdir_www}/conf.d/.
 %endif
 
 rm -f $RPM_BUILD_ROOT/%{_libdir}/robinhood/librbh_mod_*.a
@@ -246,6 +266,9 @@ cp -a doc/templates $RPM_BUILD_ROOT/%{_datadir}/robinhood/doc
 mkdir -p  $RPM_BUILD_ROOT/%{_unitdir}
 install -m 444 scripts/robinhood.service $RPM_BUILD_ROOT/%{_unitdir}/robinhood.service
 install -m 444 scripts/robinhood@.service $RPM_BUILD_ROOT/%{_unitdir}/robinhood@.service
+%if %{defined suse_version}
+ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcrobinhood 
+%endif
 
 %if %{with lustre}
 %post lustre
@@ -360,9 +383,17 @@ rm -rf $RPM_BUILD_ROOT
 %files webgui
 
 # set apache permissions
+%if %{defined suse_version}
+%defattr(640, root, www, 750)
+%else
 %defattr(640, root, apache, 750)
+%endif
+
 %{installdir_www}/robinhood
-%config(noreplace) %{_sysconfdir}/httpd/conf.d/robinhood.conf
+%config(noreplace) %{_sysconfdir}/%{confdir_www}/conf.d/robinhood.conf
+%dir %{installdir_www}
+%dir %{_sysconfdir}/%{confdir_www}/conf.d
+%dir %{_sysconfdir}/%{confdir_www}
 
 
 %files tests
@@ -413,11 +444,20 @@ rm -rf $RPM_BUILD_ROOT
 
 %{_mandir}/man1/*
 
+%if (0%{?fedora} || 0%{?rhel})
 %config(noreplace) %{_sysconfdir}/sysconfig/robinhood
+%endif
 
 %dir %{_sysconfdir}/robinhood.d
 %dir %{_sysconfdir}/robinhood.d/includes
 %dir %{_sysconfdir}/robinhood.d/templates
+
+%dir %{_libdir}/robinhood
+
+%if %{defined suse_version}
+/usr/sbin/rcrobinhood 
+%endif
+
 
 %{_sysconfdir}/ld.so.conf.d/robinhood.conf
 
@@ -432,6 +472,10 @@ rm -rf $RPM_BUILD_ROOT
 %config %{_sysconfdir}/robinhood.d/includes/check.inc
 %config %{_sysconfdir}/robinhood.d/templates/example.conf
 %config %{_sysconfdir}/robinhood.d/templates/basic.conf
+
+%if %{defined suse_version}
+%config %{_sysconfdir}/ld.so.conf.d/robinhood.conf
+%endif
 
 %if %{with_systemd}
 %{_unitdir}/robinhood.service

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,5 @@
 AM_CFLAGS= $(CC_OPT) $(DB_CFLAGS) $(PURPOSE_CFLAGS)
+AM_LDFLAGS=-ldl
 
 noinst_LTLIBRARIES=libcommontools.la
 

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -1,5 +1,5 @@
-AM_CFLAGS= -static $(CC_OPT) $(DB_CFLAGS) $(PURPOSE_CFLAGS)
-AM_LDFLAGS= -lpthread -static
+AM_CFLAGS= $(CC_OPT) $(DB_CFLAGS) $(PURPOSE_CFLAGS) # -static
+AM_LDFLAGS= -lpthread # -static
 
 # See autotools/m4/ax_valgrind_check.m4 for documentation
 @VALGRIND_CHECK_RULES@


### PR DESCRIPTION
Dear robinhood team, 
in order to get robinhood complied on build.opensuse.org I have made some small chnages in the Makefiles and some bigger changes in the spec file itself. On build.opensuse.org is compiles for 
* Factory
* Tumbleweed
* Centos 7
kind regards,
Christian