### PR TITLE
Allow to override build date

### DIFF
--- a/src/robinhood/Makefile.am
+++ b/src/robinhood/Makefile.am
@@ -6,7 +6,7 @@ AM_LDFLAGS= -lpthread -rpath $(pkglibdir)
 #FS_CFLAGS=-DLUSTRE_VERSION=\"$(LVERSION)\"
 #endif
 
-DATE=`date '+%F %T'`
+DATE=`date --utc --date @$${SOURCE_DATE_EPOCH:-$$(date +%s)} '+%F %T'`
 MISC_FLAGS="-DCOMPIL_DATE=\"$(DATE)\""
 
 noinst_LTLIBRARIES=librbhhelpers.la


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Note: only works with GNU date

Alternative solution is to drop the compile date completely.