### PR TITLE
Added option for showing files in web GUI.

### DIFF
--- a/web_gui/gui_v3/config.php
+++ b/web_gui/gui_v3/config.php
@@ -62,6 +62,8 @@ $JSON_OPTIONS = null;
 if (version_compare(phpversion(), '5.4.0', '>='))
     $JSON_OPTIONS |= JSON_PRETTY_PRINT;
 
+$SHOW_FILES = True;
+
 /*****************************
 *       ChartJS/dataTable    *
 *****************************/

--- a/web_gui/gui_v3/index.php
+++ b/web_gui/gui_v3/index.php
@@ -96,7 +96,9 @@ foreach ($fields as $field) {
         echo '<li><a href="#" onclick="GetGraph(\''.$field.'\')">'.l($field).'</a></li>';
 }
 
-echo '<li><a href="#"  onclick="GetGraph(\'Files\')">Files</a></li>';
+if ($SHOW_FILES == True) {
+        echo '<li><a href="#"  onclick="GetGraph(\'Files\')">Files</a></li>';
+}
 
 echo plugins_call("ui_menu_top", "<!--Data from plugins-->\n");
 ?>
@@ -116,15 +118,20 @@ echo plugins_call("ui_menu_top", "<!--Data from plugins-->\n");
             <fieldset class="form-group">
                 <input type="text" class="form-control" id="formGID" name="gid" placeholder="GID">
             </fieldset>
-            <fieldset class="form-group">
+
+<?php
+if ($SHOW_FILES == True) {
+      echo '<fieldset class="form-group">
                 <input type="text" class="form-control" id="formFilename" name="filename" placeholder="Filename">
             </fieldset>
 
             <fieldset class="form-group">
             <label>Size range</label>
-            <input id="ex1" data-slider-id='ex1Slider' type="text" name=minsize />
-            <input id="ex2" data-slider-id='ex2Slider' type="text" name=maxsize />
-            </fieldset>
+            <input id="ex1" data-slider-id=\'ex1Slider\' type="text" name=minsize />
+            <input id="ex2" data-slider-id=\'ex2Slider\' type="text" name=maxsize />
+            </fieldset>';
+}
+?>
 
 <script>
 $('#ex1').slider({


### PR DESCRIPTION
Hello there, 

I would like to propose a option for showing files in the Robinhood web GUI.

The feature can be enabled/disabled by modifying the config.php file:

$SHOW_FILES = True/False;


Since database queries based on file names and sizes are relatively expensive under special circumstances, we cut that feature complete off.

But instead it would be very helpful and maintainable to keep with the upstream do allow the administrator to enable/disable that feature.

We had already the discussion in the past, that adding indexes on the queried database table fields would improve the performance, but would have also its drawbacks e.g. worse insert performance on the tables or besides that it would also result in larger disc space required for the table indexes.

Please let me know what you think.

Best regards
Gabriele