### PR TITLE
Set header for customjs/param.php to js

### DIFF
--- a/web_gui/gui_v3/customjs/param.php
+++ b/web_gui/gui_v3/customjs/param.php
@@ -14,6 +14,8 @@ include("../config.php");
 include("../common.php");
 include("../plugin.php");
 
+header('Content-Type: application/javascript');
+
 foreach($CHARTJS as $conf => $val)
 {
         echo "$conf=$val;\n";


### PR DESCRIPTION
Firefox doesn't know what to do with a php file in <script> tag without a content-type header set.

This allows all of the responsive graphs to work by default.