### PR TITLE
Robinhood Sync Acceleration for PanFS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ CFLAGS="$CFLAGS $GLIB2_CFLAGS $GTHREAD2_CFLAGS"
 LDFLAGS="$LDFLAGS $GLIB2_LIBS $GTHREAD2_LIBS"
 
 # debug flags
+
 AX_ENABLE_FLAG([debug-db], [enables debug traces for database operations], [-D_DEBUG_DB])
 AX_ENABLE_FLAG([debug-parsing], [enables debug traces for configuration file parsing], [-D_DEBUG_PARSING])
 AM_CONDITIONAL(DEBUG_PARSING, test "x$enable_debug_parsing" == "xyes" )
@@ -147,6 +148,7 @@ build_lustre="OFF"
 build_backup="OFF"
 build_lhsm="OFF"
 build_shook="OFF"
+build_panfs="OFF"
 
 AC_ARG_ENABLE([lustre], AS_HELP_STRING([--disable-lustre],
               [Disable all lustre specific features]),
@@ -154,9 +156,22 @@ AC_ARG_ENABLE([lustre], AS_HELP_STRING([--disable-lustre],
 AC_ARG_ENABLE([shook], AS_HELP_STRING([--disable-shook],
               [Disable build of shook specific modules]),
               [support_shook="$enableval"],[support_shook="yes"])
+AC_ARG_ENABLE([panfs], AS_HELP_STRING([--enable-panfs],
+              [enable PanFS-specific features]),
+              [support_panfs="yes"],[support_panfs="no"])
 
 # default input option is --scan
 INPUT_OPT="--scan"
+
+# Panasas File System
+if test "x$support_panfs" = "xyes" ; then
+    AC_DEFINE(_PANFS, 1, [panfs is available])
+    AM_CONDITIONAL( PANFS, test "x$support_panfs" = "xyes" )
+    AC_SUBST(PANFS)
+    build_panfs="ON"
+else
+    AM_CONDITIONAL(PANFS, test 0 = 1 )
+fi
 
 # shook requires Lustre + FID support + shook library
 # hsm_lite requires Lustre + FID support
@@ -490,6 +505,7 @@ AC_SUBST(ac_configure_args)
 AC_OUTPUT
 
 AC_MSG_NOTICE([Summary:])
+AC_MSG_NOTICE([PanFS      support is $build_panfs])
 AC_MSG_NOTICE([Lustre     support is $build_lustre])
 AC_MSG_NOTICE([Backup     support is $build_backup])
 AC_MSG_NOTICE([Lustre/HSM support is $build_lhsm])

--- a/src/cfg_parsing/rbh_cfg.c
+++ b/src/cfg_parsing/rbh_cfg.c
@@ -33,6 +33,7 @@
 #include "policy_rules.h"
 #include "policy_run.h"
 #include "status_manager.h"
+#include "panfs_config.h"
 
 char config_file[RBH_PATH_MAX] = "";
 
@@ -43,6 +44,9 @@ struct mod_cfgs {
     {&global_cfg_hdlr,     MODULE_MASK_ALWAYS},
     {&log_cfg_hdlr,        MODULE_MASK_ALWAYS},
     {&updt_params_hdlr,    MODULE_MASK_ALWAYS},
+#ifdef _PANFS
+    {&panfs_cfg_hdlr,      MODULE_MASK_ALWAYS},
+#endif
     {&lmgr_cfg_hdlr,       MODULE_MASK_ALWAYS},
     {&entry_proc_cfg_hdlr, MODULE_MASK_ENTRY_PROCESSOR},
     {&fs_scan_cfg_hdlr,    MODULE_MASK_FS_SCAN},
@@ -144,7 +148,7 @@ static int rbh_cfg_read_set(int module_mask, char *file_path, char *err_msg_out,
             /* just free the top level handler */
             free(cfg);
     }
-
+   
  config_free:
     /* free config file resources */
     rh_config_Free(syntax_tree);

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -6,6 +6,9 @@ noinst_LTLIBRARIES=libcommontools.la
 if LUSTRE
 FS_SRC=lustre_tools.c
 endif
+if PANFS
+FS_SRC=panfs_config.c
+endif
 if MNTENTCOMPAT
 COMPAT_SRC=mntent_compat.c mntent_compat.h
 endif

--- a/src/common/panfs_config.c
+++ b/src/common/panfs_config.c
@@ -1,0 +1,179 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ * vim:expandtab:shiftwidth=4:tabstop=4:
+ */
+/*
+ * Copyright (C) 2008, 2009 CEA/DAM
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the CeCILL License.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL license (http://www.cecill.info) and that you
+ * accept its terms.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "panfs_config.h"
+#include "rbh_cfg_helpers.h"
+#include "rbh_misc.h"
+#include "rbh_logs.h"
+#include <errno.h>
+
+#define PANFS_CONFIG_BLOCK "Panasas"
+
+/* exported variable available to all modules */
+panfs_config_t panfs_config;
+
+static void panfs_cfg_set_default(void *module_config)
+{
+    panfs_config_t *conf = (panfs_config_t *)module_config;
+    rh_strncpy(conf->snap_delta_path, "", RBH_PATH_MAX);
+    rh_strncpy(conf->snap_delta_results_path, "", RBH_PATH_MAX);
+    rh_strncpy(conf->volume, "", FILENAME_MAX);
+    conf->update_interval = 600;//10 min
+}
+
+static void panfs_cfg_write_default(FILE *output)
+{
+    print_begin_block(output, 0, PANFS_CONFIG_BLOCK, NULL);
+    print_line(output, 1, "snap_delta_path       :  PATH");
+    print_line(output, 1, "snap_delta_results_path       :  PATH");
+    print_line(output, 1, "volume        :  volumeName");
+    print_line(output, 1, "# Interval for updating database");
+    print_line(output, 1, "update_interval = 10min ;");
+    fprintf(output, "\n");
+    print_end_block(output, 0);
+}
+
+static int panfs_cfg_read(config_file_t config, void *module_config,
+                           char *msg_out)
+{
+    panfs_config_t *conf = (panfs_config_t *)module_config;
+    config_item_t    panfs_block;
+    int              rc;
+
+    static const char * const allowed_params[] = {
+        "snap_delta_path", "snap_delta_results_path", "volume", "update_interval", NULL
+    };
+    const cfg_param_t cfg_params[] = {
+        {"snap_delta_path", PT_STRING, PFLG_MANDATORY  |
+         PFLG_REMOVE_FINAL_SLASH | PFLG_NO_WILDCARDS, conf->snap_delta_path,
+         sizeof(conf->snap_delta_path)}
+        ,
+        {"snap_delta_results_path", PT_STRING, PFLG_MANDATORY  |
+         PFLG_REMOVE_FINAL_SLASH | PFLG_NO_WILDCARDS, conf->snap_delta_results_path,
+         sizeof(conf->snap_delta_results_path)}
+        ,
+        {"volume", PT_STRING,
+         PFLG_MANDATORY |
+         PFLG_NO_WILDCARDS, conf->volume, sizeof(conf->volume)}
+        ,
+        {"update_interval", PT_DURATION, PFLG_POSITIVE | PFLG_NOT_NULL,
+         &conf->update_interval, 0}
+        ,
+
+        END_OF_PARAMS
+    };
+
+    /* get PANASAS block */
+    rc = get_cfg_block(config, PANFS_CONFIG_BLOCK, &panfs_block, msg_out);
+    if (rc)
+        return rc;
+
+    /* retrieve std parameters */
+    rc = read_scalar_params(panfs_block, PANFS_CONFIG_BLOCK, cfg_params,
+                            msg_out);
+    if (rc)
+        return rc;
+
+    /* check unknown parameters */
+    CheckUnknownParameters(panfs_block, PANFS_CONFIG_BLOCK, allowed_params);
+
+    return 0;
+}
+
+static int panfs_cfg_set(void *module_config, bool reload)
+{
+    panfs_config_t *conf = (panfs_config_t *) module_config;
+
+    if (!reload) {
+        /* copy the whole structure content */
+        panfs_config = *conf;
+        return 0;
+    }
+
+    if (strcmp(conf->snap_delta_path, panfs_config.snap_delta_path)){
+        DisplayLog(LVL_MAJOR, "PanasasConfig",
+                   PANFS_CONFIG_BLOCK
+                   "::Path to pan_snap_delta updated");
+	strcpy(panfs_config.snap_delta_path,conf->snap_delta_path);
+	
+    }
+    if (strcmp(conf->snap_delta_results_path, panfs_config.snap_delta_results_path)){
+        DisplayLog(LVL_MAJOR, "PanasasConfig",
+                   PANFS_CONFIG_BLOCK
+                   "::Path to pan_snap_delta results updated");
+	strcpy(panfs_config.snap_delta_results_path,conf->snap_delta_results_path);
+	
+    }
+    if (strcmp(conf->volume, panfs_config.volume)){
+        DisplayLog(LVL_MAJOR, "PanasasConfig",
+                   PANFS_CONFIG_BLOCK
+                   "::Volume's name changed in config file, but cannot be modified dynamically. If you need to change it, drop the database and run it one more time.");
+        exit(1);
+    }
+    if (panfs_config.update_interval != conf->update_interval) {
+        DisplayLog(LVL_MAJOR, "PanasasConfig",
+                   PANFS_CONFIG_BLOCK "::update_interval modified: "
+                   "'%" PRI_TT "'->'%" PRI_TT "'",
+                   panfs_config.update_interval, conf->update_interval);
+        panfs_config.update_interval = conf->update_interval;
+    } 
+    return 0;
+}
+
+static void panfs_cfg_write_template(FILE *output)
+{
+    print_begin_block(output, 0, PANFS_CONFIG_BLOCK, NULL);
+    print_line(output, 1,
+               "# Path to pan_snap_delta binary");
+    print_line(output, 1, "snap_delta_path =  \"/panfs/\" ;");
+    fprintf(output, "\n");
+    print_line(output, 1,
+               "# Path to pan_snap_delta results");
+    print_line(output, 1, "snap_delta_results_path =  \"/tmp/\" ;");
+    fprintf(output, "\n");
+    print_line(output, 1, "# Name of the volume");
+    print_line(output, 1, "volume = home;");
+    fprintf(output, "\n");
+    print_line(output, 1,
+               "# Time between checks to see if there are newer snapshots to process");
+   
+    print_line(output, 1, " update_interval=10m;");
+    print_end_block(output, 0);
+}
+
+static void *panfs_cfg_new(void)
+{
+    return calloc(1, sizeof(panfs_config_t));
+}
+
+static void panfs_cfg_free(void *cfg)
+{
+    if (cfg != NULL) 
+        free(cfg);
+}
+
+/** structure with config handling functions */
+mod_cfg_funcs_t panfs_cfg_hdlr = {
+    .module_name = "panasas",
+    .new = panfs_cfg_new,
+    .free = panfs_cfg_free,
+    .set_default = panfs_cfg_set_default,
+    .read = panfs_cfg_read,
+    .set_config = panfs_cfg_set,
+    .write_default = panfs_cfg_write_default,
+    .write_template = panfs_cfg_write_template
+};

--- a/src/fs_scan/fs_scan_main.c
+++ b/src/fs_scan/fs_scan_main.c
@@ -39,6 +39,14 @@ static void *scan_starter(void *arg)
 
     DisplayLog(LVL_VERB, FSSCAN_TAG, "Launching FS Scan starter thread");
 
+#ifdef _PANFS
+    rc = Robinhood_CheckScanDeadlines();
+    if (rc)
+        DisplayLog(LVL_CRIT, FSSCAN_TAG, "Error %d checking FS Scan status",
+                  rc);
+    pthread_exit(NULL);
+    return NULL;
+#else
     if (fsscan_flags & RUNFLG_ONCE) {
         rc = Robinhood_CheckScanDeadlines();
         if (rc)
@@ -59,6 +67,7 @@ static void *scan_starter(void *arg)
         rh_sleep(fs_scan_config.spooler_check_interval);
     }
 
+#endif
     return NULL;
 }
 

--- a/src/include/list_mgr.h
+++ b/src/include/list_mgr.h
@@ -1074,6 +1074,10 @@ void ListMgr_CloseProfile(struct lmgr_profile_t *p_iter);
 
 // Scan statistics
 #define LAST_SCAN_START_TIME  "LastScanStartTime"
+#ifdef _PANFS
+#define SNAPSHOT_PATH  "SnapPath"
+#define SNAPSHOT_DONE  "SnapDone"
+#endif
 #define LAST_SCAN_END_TIME    "LastScanEndTime"
 #define LAST_SCAN_PROCESSING_END_TIME "LastScanProcessingEndTime"
 #define LAST_SCAN_STATUS      "LastScanStatus"

--- a/src/include/panfs_config.h
+++ b/src/include/panfs_config.h
@@ -1,0 +1,47 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+ * vim:expandtab:shiftwidth=4:tabstop=4:
+ */
+/*
+ * Copyright (C) 2008, 2009 CEA/DAM
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the CeCILL License.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL license (http://www.cecill.info) and that you
+ * accept its terms.
+ */
+
+/**
+ * \file  panfs_config.h
+ * \brief Panasas configuration parameters
+ */
+#ifndef _PANFS_CFG_H
+#define _PANFS_CFG_H
+
+#include "config_parsing.h"
+#include "rbh_cfg.h"
+#include "rbh_const.h"
+#include <sys/param.h>  /* for RBH_PATH_MAX */
+#include <stdio.h>
+#include <stdbool.h>
+
+/**
+ * General Panasas configuration
+ */
+typedef struct panfs_config_t {
+    /* filesystem description */
+    char    snap_delta_path[RBH_PATH_MAX];
+    char    snap_delta_results_path[RBH_PATH_MAX];
+    char    volume[FILENAME_MAX];
+    time_t     update_interval;
+   
+} panfs_config_t;
+
+/** panasas config structure available to all modules */
+extern panfs_config_t panfs_config;
+
+/** handlers for panasas config */
+extern mod_cfg_funcs_t panfs_cfg_hdlr;
+
+#endif

--- a/src/robinhood/rbh_find.c
+++ b/src/robinhood/rbh_find.c
@@ -21,6 +21,9 @@
 #include "config.h"
 #endif
 
+#ifdef _PANFS
+#include "panfs_config.h"
+#endif
 #include "list_mgr.h"
 #include "cmd_helpers.h"
 #include "rbh_cfg.h"


### PR DESCRIPTION
This pull request contains changes made this summer by employees at Panasas to provide support akin to what already exists for Lustre to accelerate updates to the Robinhood DB for the Panasas filesystem.  Unlike in Lustre, which leverages it's changelog to keep the Robinhood DB up-to-date, in this change we use the PanFS snapshot delta utility to compute differences between successive snapshots, track which was the last snapshot we successfully updated from, and update when a newer snapshot is available using just the computed differences.

In the interest of de-risking existing users of Lustre or just the POSIX version of Robinhood that does a full tree walk, we compile out almost all of our code unless --enable-panfs is passed to configure.

Detailed changes include the following:
- Adjust configure with new --enable-panfs build flag
- Add new panfs configuration section to robinhood config file
- Parse configuration section appropriately via panfs_config.c
- Adjust code in rbh_misc.c and fs_scan.c to use Panasas object ID's in lieu of inodes to avoid confusion (as snapshots do not have the same inode even if nothing changed).  These Panasas object ID's are available via xattrs.
- In rbh_daemon.c added all of the following:
- New PanFS-specific CLI arguments
- All needed functions that can directly modify mysql to reflect the changes we observe between snapshots as reported by pan_snap_delta
- Functionality to actually identify if new snapshots exist and run pan_snap_delta against that and the last successfully updated snapshot
- Processing engine to filter and sort the output from pan_snap_delta into a format useful for inputting to the mysql functions to update the robinhood db

Please let me know if there are any issues with the code in this request and I'll be glad to make modifications to alleviate such concerns.  Thanks!