### PR TITLE
Replace quotes in README.md with code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,16 @@ mailx, bison, flex.
 For lustre support: lustre or lustre-client
 
 Unzip and untar the source distribution:
-> tar zxvf robinhood-3.x.x.tar.gz
-> cd robinhood-3.x.x
+```
+tar zxvf robinhood-3.x.x.tar.gz
+cd robinhood-3.x.x
+```
 
 Configure and build:
-> ./configure
-> make rpm
+```
+./configure
+make rpm
+```
 
 RPMs are generated in the 'rpms/RPMS/*arch*' directory.
 
@@ -38,13 +42,17 @@ RPMs are generated in the 'rpms/RPMS/*arch*' directory.
 -------------------------
 
 Install git, and autotools stuff:
-> yum install git automake autoconf libtool
+```
+yum install git automake autoconf libtool
+```
 
 Retrieve robinhood sources
-> git clone https://github.com/cea-hpc/robinhood.git
-> cd robinhood
-> git checkout master *(or other branch)*
-> sh autogen.sh
+```
+git clone https://github.com/cea-hpc/robinhood.git
+cd robinhood
+git checkout master *(or other branch)*
+sh autogen.sh
+```
 
 Then refer to section 2.1 for next compilation steps.
 
@@ -55,21 +63,29 @@ Then refer to section 2.1 for next compilation steps.
 Only requirements: rpm-build, gcc, flex, bison
 
 To create src rpm on a host with minimal requirements, run:
-> ./configure --enable-dist
-> make srpm
+```
+./configure --enable-dist
+make srpm
+```
 
 ### 2.3.2 - Building from src rpm
 By default, the src rpm builds robinhood for POSIX filesystems:
-> rpmbuild --rebuild robinhood-3.0*.src.rpm
+```
+rpmbuild --rebuild robinhood-3.0*.src.rpm
+```
 
 To build robinhood binary RPM for a Lustre filsystem, run:
-> rpmbuild --rebuild robinhood-3.0*.src.rpm --with lustre --define "lversion x.y"
+```
+rpmbuild --rebuild robinhood-3.0*.src.rpm --with lustre --define "lversion x.y"
+```
 
 where x.y is your target lustre version (e.g. 2.7).
 
 Note: if lustre-client is not installed on your target system, you can specify
 an alternative lustre package by defining "lpackage", e.g.
-> rpmbuild [...] --define "lpackage lustre"
+```
+rpmbuild [...] --define "lpackage lustre"
+```
 
 Note: 'lversion' can be omitted, by it is strongly recommanded to prevent
 incompatibility issues between lustreapi versions.
@@ -95,7 +111,9 @@ This database can run on a different node from Robinhood daemon.
     * RHEL7: systemctl start mariadb
 * Run the configuration helper script as root on the database host to create
 the database:
-> rbh-config create_db
+```
+rbh-config create_db
+```
 
 * Write the DB password to a file with read access for root only (600)
   e.g. to /etc/robinhood.d/.dbpassword
@@ -107,7 +125,9 @@ V - Lustre 2.x Filesystems only: enabling changelogs
 For Lustre, you must register robinhood as a MDT changelog consumer.
 
 * Run the configuration helper script on Lustre MDS:
-> rbh-config enable_chglogs
+```
+rbh-config enable_chglogs
+```
 
   This registers a changelog consumer and activate required changelog records.
 
@@ -120,7 +140,9 @@ VI - Configuration file
 Examples of config files are installed in /etc/robinhood.d/templates/
 
 You can also use the '--template' option to generate a documented configuration file template:
-> robinhood --template=<template_file>
+```
+robinhood --template=<template_file>
+```
 
 For more details, refer to [Robinhood v3 admin guide](https://github.com/cea-hpc/robinhood/wiki/robinhood_v3_admin_doc).
 
@@ -131,7 +153,9 @@ VII - First run
 
 Even if your filesystem is empty, you need to perform an initial scan in order to initialize robinhood database.
 This prevents from having entries in filesystem that it wouldn't know about.
-> robinhood --scan --once
+```
+robinhood --scan --once
+```
 
 VIII - Start the daemon
 =======================
@@ -139,11 +163,17 @@ VIII - Start the daemon
 * [el7] Configure per-filesystem daemon options in **/etc/sysconfig/robinhood.\<fsname\>**
 
 Example: to read lustre changelogs and run all policies:
-> RBH_OPT="--readlog --run=all"
+```
+RBH_OPT="--readlog --run=all"
+```
 
 Example: to regularly scan filesystem and run all policies:
-> RBH_OPT="--scan --run=all"
+```
+RBH_OPT="--scan --run=all"
+```
 
 Start the daemon:
-> [el6] service robinhood start
-> [el7] systemctl start robinhood@*fsname*
+```
+[el6] service robinhood start
+[el7] systemctl start robinhood@*fsname*
+```


### PR DESCRIPTION
Using quotes makes the code squeeze into one single line, and may cause problems if a newcomer wants to directly copy commands and execute. Replace quotes with code blocks enables line returns to actually work, and anyone who wants to copy commands can easily use them.