### PR TITLE
allow 'systemctl enable' and ensure start after local and remote fs

### DIFF
--- a/scripts/robinhood.service.in
+++ b/scripts/robinhood.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Robinhood server
+After=local-fs.target remote-fs.target
+Requires=local-fs.target
 #only works if config file is unique
 
 [Service]
@@ -9,3 +11,6 @@ EnvironmentFile=-@CONFDIR@/sysconfig/robinhood
 LimitNOFILE=8096
 ExecStart=@SBINDIR@/robinhood $RBH_OPT
 ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/robinhood@.service.in
+++ b/scripts/robinhood@.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Robinhood server for %I
+After=local-fs.target remote-fs.target
+Requires=local-fs.target
 
 [Service]
 Type=simple
@@ -9,3 +11,6 @@ EnvironmentFile=-@CONFDIR@/sysconfig/robinhood.%I
 LimitNOFILE=8096
 ExecStart=@SBINDIR@/robinhood $RBH_OPT -f @CONFDIR@/robinhood.d/%I.conf
 ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Current service file missing [Install] section, causing:
```
# systemctl enable robinhood.service
The unit files have no installation config (WantedBy, RequiredBy, Also, Alias
settings in the [Install] section, and DefaultInstance for template units).
This means they are not meant to be enabled using systemctl.
```

Also, add dependency to ensure robinhood start after local and remote fs