### PR TITLE
WIP: add Lustre project ID support

### DIFF
--- a/src/cfg_parsing/rbh_boolexpr.c
+++ b/src/cfg_parsing/rbh_boolexpr.c
@@ -145,6 +145,10 @@ static struct criteria_descr_t {
     [CRITERIA_TYPE] = {"type", ATTR_MASK_type, PT_TYPE, 0, 0},
     [CRITERIA_OWNER] = {"owner", ATTR_MASK_uid, PT_STRING, PFLG_NOT_EMPTY, 0},
     [CRITERIA_GROUP] = {"group", ATTR_MASK_gid, PT_STRING, PFLG_NOT_EMPTY, 0},
+#ifdef _LUSTRE
+    [CRITERIA_PROJID] = {"projid", ATTR_MASK_projid, PT_INT,
+                         PFLG_POSITIVE | PFLG_COMPARABLE, 0},
+#endif
     [CRITERIA_SIZE] = {"size", ATTR_MASK_size, PT_SIZE,
                        PFLG_POSITIVE | PFLG_COMPARABLE, 0},
     [CRITERIA_DEPTH] = {"depth", ATTR_MASK_depth, PT_INT,

--- a/src/common/global_config.c
+++ b/src/common/global_config.c
@@ -58,6 +58,10 @@ static void global_cfg_set_default(void *module_config)
 #if defined(_LUSTRE) && defined(_MDS_STAT_SUPPORT)
     conf->direct_mds_stat = false;
 #endif
+
+#ifdef _LUSTRE
+    conf->lustre_projid = false;
+#endif
 }
 
 static void global_cfg_write_default(FILE *output)
@@ -78,6 +82,9 @@ static void global_cfg_write_default(FILE *output)
 #if defined(_LUSTRE) && defined(_MDS_STAT_SUPPORT)
     print_line(output, 1, "direct_mds_stat :   no");
 #endif
+#ifdef _LUSTRE
+    print_line(output, 1, "lustre_projid :  no");
+#endif
     print_end_block(output, 0);
 }
 
@@ -91,7 +98,7 @@ static int global_cfg_read(config_file_t config, void *module_config,
     static const char * const allowed_params[] = {
         "fs_path", "fs_type", "stay_in_fs", "check_mounted",
         "direct_mds_stat", "fs_key", "last_access_only_atime",
-        "uid_gid_as_numbers", NULL
+        "uid_gid_as_numbers", "lustre_projid", NULL
     };
     const cfg_param_t cfg_params[] = {
         {"fs_path", PT_STRING, PFLG_MANDATORY | PFLG_ABSOLUTE_PATH |
@@ -114,6 +121,10 @@ static int global_cfg_read(config_file_t config, void *module_config,
         ,
 #if defined(_LUSTRE) && defined(_MDS_STAT_SUPPORT)
         {"direct_mds_stat", PT_BOOL, 0, &conf->direct_mds_stat, 0}
+        ,
+#endif
+#ifdef _LUSTRE
+        {"lustre_projid", PT_BOOL, 0, &conf->lustre_projid, 0}
         ,
 #endif
         END_OF_PARAMS
@@ -222,6 +233,15 @@ static int global_cfg_set(void *module_config, bool reload)
     }
 #endif
 
+#ifdef _LUSTRE
+    if (conf->lustre_projid != global_config.lustre_projid) {
+        DisplayLog(LVL_EVENT, "FS_Scan_Config",
+                   GLOBAL_CONFIG_BLOCK "::lustre_projid updated: %u->%u",
+                   global_config.lustre_projid, conf->lustre_projid);
+        global_config.lustre_projid = conf->lustre_projid;
+    }
+#endif
+
     return 0;
 }
 
@@ -267,6 +287,9 @@ static void global_cfg_write_template(FILE *output)
                "# File info is asked directly to MDS on Lustre filesystems");
     print_line(output, 1, "# (scan faster, but size information is missing)");
     print_line(output, 1, "direct_mds_stat        =    no ;");
+#endif
+#ifdef _LUSTRE
+    print_line(output, 1, "lustre_projid          =    no ;");
 #endif
     print_end_block(output, 0);
 }

--- a/src/common/rbh_misc.c
+++ b/src/common/rbh_misc.c
@@ -2709,6 +2709,46 @@ int set_gid_val(const char *groupname, db_type_u *val)
     return 0;
 }
 
+/* Resolved numerical project ID from a string.
+ * Return 0 on success, and non-zero on error. */
+int set_projid_val(const char *projidname, db_type_u *val)
+{
+    long projid;
+    char *endptr;
+
+    if (WILDCARDS_IN(projidname)) {
+        DisplayLog(LVL_CRIT, __func__,
+                   "ERROR: Wilcards not allowed in projid");
+        return -1;
+    }
+
+    errno = 0;
+    projid = strtol(projidname, &endptr, 0);
+
+    if ((errno == ERANGE && (projid == LONG_MAX || projid == LONG_MIN)) ||
+        (errno != 0 && projid == 0) || endptr == projidname) {
+        /* Not a number. */
+        DisplayLog(LVL_CRIT, __func__,
+                   "couldn't resolve projid for project '%s'", projidname);
+        return -1;
+    }
+
+    if (projid < 0) {
+        DisplayLog(LVL_CRIT, __func__,
+                   "ERROR: Given PROJID is negative (%ld)", projid);
+        return -1;
+    }
+
+    if (projid > UINT_MAX) {
+        DisplayLog(LVL_CRIT, __func__,
+                   "ERROR: Given PROJID is too big (%ld)", projid);
+        return -1;
+    }
+
+    val->val_int = projid;
+    return 0;
+}
+
 /* Returns a printable string for a UID or GID, whether it's a number
  * or an actual string. */
 const char *id_as_str(db_type_u *val)

--- a/src/entry_processor/std_pipeline.c
+++ b/src/entry_processor/std_pipeline.c
@@ -1404,14 +1404,14 @@ int EntryProc_get_info_fs(struct entry_proc_op_t *p_op, lmgr_t *lmgr)
     /* projid: currently, only file and dir supported */
     if (global_config.lustre_projid && NEED_GETPROJID(p_op)
         && ATTR_FSorDB_TEST(p_op, type)
-        && (strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_FILE) != 0
-            || strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_DIR) != 0)) {
-        /* */
+        && (!strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_FILE)
+            || !strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_DIR))) {
+        /* file or dir, get project id */
         rc = lustre_project_get_id(path);
         if (rc < 0)  {
             DisplayLog(LVL_MAJOR, ENTRYPROC_TAG,
-                       "Failed to get lustre projid for %s: error %d",
-                       path, rc);
+                       "Failed to get lustre projid for %s (%s): error %d",
+                       path, ATTR_FSorDB(p_op, type), rc);
         } else {
             DisplayLog(LVL_FULL, ENTRYPROC_TAG, DFID ": projid=%u",
                        PFID(&p_op->entry_id), rc);

--- a/src/entry_processor/std_pipeline.c
+++ b/src/entry_processor/std_pipeline.c
@@ -271,7 +271,8 @@ static int EntryProc_FillFromLogRec(struct entry_proc_op_t *p_op,
                 = cltime2sec(logrec->cr_time);
 
             /* force updating attributes */
-            p_op->fs_attr_need.std |= POSIX_ATTR_MASK | ATTR_MASK_stripe_info;
+            p_op->fs_attr_need.std |= POSIX_ATTR_MASK | ATTR_MASK_stripe_info
+                                      | ATTR_MASK_projid;
             /* get status for all policies with a matching scope */
             add_matching_scopes_mask(&p_op->entry_id, &p_op->fs_attrs, true,
                                      &p_op->fs_attr_need.status);
@@ -330,6 +331,11 @@ static int EntryProc_FillFromLogRec(struct entry_proc_op_t *p_op,
     else if (logrec->cr_type == CL_LAYOUT) {
         attr_mask_set_index(&p_op->fs_attr_need, ATTR_INDEX_stripe_info);
         attr_mask_set_index(&p_op->fs_attr_need, ATTR_INDEX_stripe_items);
+    }
+#endif
+#ifdef _LUSTRE
+    else if (logrec->cr_type == CL_SETATTR) {
+        attr_mask_set_index(&p_op->fs_attr_need, ATTR_INDEX_projid);
     }
 #endif
 
@@ -530,7 +536,7 @@ static int EntryProc_ProcessLogRec(struct entry_proc_op_t *p_op)
              */
             tmp.std = (POSIX_ATTR_MASK | ATTR_MASK_name | ATTR_MASK_parent_id
                        | ATTR_MASK_stripe_info | ATTR_MASK_stripe_items
-                       | ATTR_MASK_link);
+                       | ATTR_MASK_link | ATTR_MASK_projid);
             tmp = attr_mask_and_not(&tmp, &p_op->fs_attrs.attr_mask);
             p_op->fs_attr_need = attr_mask_or(&p_op->fs_attr_need, &tmp);
 
@@ -558,6 +564,15 @@ static int EntryProc_ProcessLogRec(struct entry_proc_op_t *p_op)
                 ((p_op->fs_attrs.attr_mask.std & POSIX_ATTR_MASK) !=
                  POSIX_ATTR_MASK))
                 p_op->fs_attr_need.std |= POSIX_ATTR_MASK;
+
+            /* get projid if missing (file and dir only) */
+            if ((db_missing.std & ATTR_MASK_projid)
+                && !ATTR_MASK_TEST(&p_op->fs_attrs, projid)
+                && (!ATTR_FSorDB_TEST(p_op, type)
+                    || (!strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_FILE)
+                         && !strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_DIR)))) {
+                p_op->fs_attr_need.std |= ATTR_MASK_projid;
+            }
 
             /* get stripe info if missing (file only) */
             if ((db_missing.std & ATTR_MASK_stripe_info)
@@ -1288,11 +1303,18 @@ int EntryProc_get_info_fs(struct entry_proc_op_t *p_op, lmgr_t *lmgr)
 
     DisplayLog(LVL_FULL, ENTRYPROC_TAG,
                DFID ": Getattr=%u, Getpath=%u, Readlink=%u"
-               ", Getstatus(%s), Getstripe=%u",
+               ", Getstatus(%s), Getstripe=%u"
+#ifdef _LUSTRE
+               ", Getprojid=%u",
+#endif
                PFID(&p_op->entry_id), NEED_GETATTR(p_op) ? 1 : 0,
                NEED_GETPATH(p_op) ? 1 : 0, NEED_READLINK(p_op) ? 1 : 0,
                name_status_mask(p_op->fs_attr_need.status, tmp_buf,
-                                sizeof(tmp_buf)), NEED_GETSTRIPE(p_op) ? 1 : 0);
+                                sizeof(tmp_buf)), NEED_GETSTRIPE(p_op) ? 1 : 0,
+#ifdef _LUSTRE
+                                NEED_GETPROJID(p_op) ? 1 : 0
+#endif
+);
 
     /* don't retrieve info which is already fresh */
     p_op->fs_attr_need =
@@ -1378,6 +1400,25 @@ int EntryProc_get_info_fs(struct entry_proc_op_t *p_op, lmgr_t *lmgr)
             ATTR_MASK_SET(&p_op->fs_attrs, stripe_items);
         }
     }   /* get_stripe needed */
+
+    /* projid: currently, only file and dir supported */
+    if (global_config.lustre_projid && NEED_GETPROJID(p_op)
+        && ATTR_FSorDB_TEST(p_op, type)
+        && (strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_FILE) != 0
+            || strcmp(ATTR_FSorDB(p_op, type), STR_TYPE_DIR) != 0)) {
+        /* */
+        rc = lustre_project_get_id(path);
+        if (rc < 0)  {
+            DisplayLog(LVL_MAJOR, ENTRYPROC_TAG,
+                       "Failed to get lustre projid for %s: error %d",
+                       path, rc);
+        } else {
+            DisplayLog(LVL_FULL, ENTRYPROC_TAG, DFID ": projid=%u",
+                       PFID(&p_op->entry_id), rc);
+            ATTR_MASK_SET(&p_op->fs_attrs, projid);
+            ATTR(&p_op->fs_attrs, projid) = rc;
+        }
+    }
 #endif
 
     if (NEED_ANYSTATUS(p_op)) {

--- a/src/include/db_schema.def
+++ b/src/include/db_schema.def
@@ -111,6 +111,7 @@ avgsize,        uint64_t,      DB_BIGUINT,     0, DIR_ATTR, type, NULL
 # POSIX attrs
 uid,        uidgid_u,   DB_UIDGID,  0,   FREQ_ACCESS
 gid,        uidgid_u,   DB_UIDGID,  0,   FREQ_ACCESS
+projid,  unsigned int,   DB_UINT,    0, FREQ_ACCESS
 size,       uint64_t,   DB_BIGUINT, 0,   FREQ_ACCESS
 blocks,     uint64_t,   DB_BIGUINT, 0,   FREQ_ACCESS
 creation_time,  unsigned int,   DB_UINT,    0, FREQ_ACCESS

--- a/src/include/entry_processor.h
+++ b/src/include/entry_processor.h
@@ -218,6 +218,7 @@ typedef struct entry_proc_op_t {
                              ATTR_MASK_parent_id | ATTR_MASK_depth))
 #define NEED_GETATTR(_op) ((_op)->fs_attr_need.std & POSIX_ATTR_MASK)
 #define NEED_READLINK(_op) ((_op)->fs_attr_need.std & ATTR_MASK_link)
+#define NEED_GETPROJID(_op) ((_op)->fs_attr_need.std & ATTR_MASK_projid)
 
 /** config handlers */
 extern mod_cfg_funcs_t entry_proc_cfg_hdlr;

--- a/src/include/global_config.h
+++ b/src/include/global_config.h
@@ -56,6 +56,10 @@ typedef struct global_config_t {
     bool    direct_mds_stat;
 #endif
 
+#ifdef _LUSTRE
+    /* Lustre project ID support */
+    bool    lustre_projid;
+#endif
 } global_config_t;
 
 /** global config structure available to all modules */

--- a/src/include/policy_run.h
+++ b/src/include/policy_run.h
@@ -42,7 +42,7 @@ typedef enum {
 #ifdef _LUSTRE
     TGT_OST,    /* apply policies to the specified OST */
     TGT_POOL,   /* apply policies to the specified pool of OSTs */
-    TGT_PROJID,  /* apply policies to the specified group */
+    TGT_PROJID, /* apply policies to the specified project id */
 #endif
     TGT_USER,   /* apply policies to the specified user */
     TGT_GROUP,  /* apply policies to the specified group */

--- a/src/include/policy_run.h
+++ b/src/include/policy_run.h
@@ -42,6 +42,7 @@ typedef enum {
 #ifdef _LUSTRE
     TGT_OST,    /* apply policies to the specified OST */
     TGT_POOL,   /* apply policies to the specified pool of OSTs */
+    TGT_PROJID,  /* apply policies to the specified group */
 #endif
     TGT_USER,   /* apply policies to the specified user */
     TGT_GROUP,  /* apply policies to the specified group */
@@ -123,6 +124,8 @@ static inline char *trigger2str(const trigger_item_t *trig)
         return "ost_usage";
     case TGT_POOL:
         return "pool_usage";
+    case TGT_PROJID:
+        return "projid_usage";
 #endif
     case TGT_USER:
         return "user_usage";

--- a/src/include/rbh_boolexpr.h
+++ b/src/include/rbh_boolexpr.h
@@ -60,6 +60,7 @@ typedef enum {
 #ifdef _LUSTRE
     CRITERIA_POOL,
     CRITERIA_OST,
+    CRITERIA_PROJID,
 #endif
     CRITERIA_FILECLASS,
     CRITERIA_STATUS,

--- a/src/include/rbh_misc.h
+++ b/src/include/rbh_misc.h
@@ -355,6 +355,12 @@ char *FormatDurationFloat(char *buff, size_t str_sz, time_t duration);
  */
 void append_stripe_list(GString *str, const stripe_items_t *p_stripe_items,
                         bool brief);
+
+/**
+ * Lustre Project ID
+ */
+int lustre_project_get_id(const char *pathname);
+
 #endif
 
 /*
@@ -622,6 +628,7 @@ int path2id(const char *path, entry_id_t *id, const struct stat *st);
 
 int set_uid_val(const char *username, db_type_u *val);
 int set_gid_val(const char *groupname, db_type_u *val);
+int set_projid_val(const char *projidname, db_type_u *val);
 const char *id_as_str(db_type_u *val);
 
 #endif

--- a/src/list_mgr/database.h
+++ b/src/list_mgr/database.h
@@ -30,6 +30,7 @@
 #define ACCT_FIELD_COUNT    "count"
 #define ACCT_DEFAULT_OWNER  "unknown"
 #define ACCT_DEFAULT_GROUP  "unknown"
+#define ACCT_DEFAULT_PROJID 0
 #define SZRANGE_FUNC        "sz_range"
 #define ONE_PATH_FUNC       "one_path"
 #define THIS_PATH_FUNC      "this_path"

--- a/src/list_mgr/listmgr_init.c
+++ b/src/list_mgr/listmgr_init.c
@@ -137,6 +137,7 @@ static void append_field(db_conn_t *pconn, GString *str, bool is_first,
 
 static db_type_u default_uid = { .val_str = ACCT_DEFAULT_OWNER };
 static db_type_u default_gid = { .val_str = ACCT_DEFAULT_GROUP };
+static db_type_u default_projid = { ACCT_DEFAULT_PROJID };
 static db_type_u default_type = { .val_str = "file" };
 static db_type_u default_status = { .val_str = "" };
 static db_type_u default_zero = { 0 };
@@ -186,6 +187,8 @@ static const db_type_u *default_field_value(int attr_index)
         return &default_uid;
     case ATTR_INDEX_gid:
         return &default_gid;
+    case ATTR_INDEX_projid:
+        return &default_projid;
     default:
         if (is_status_field(attr_index)) {
             return &default_status;

--- a/src/policies/policy_matching.c
+++ b/src/policies/policy_matching.c
@@ -647,6 +647,12 @@ int criteria2filter(const compare_triplet_t *p_comp,
             p_value->value.val_str = p_comp->val.str;
         break;
 
+    case CRITERIA_PROJID:
+        *p_attr_index = ATTR_INDEX_projid;
+        *p_compar = Policy2FilterComparator(p_comp->op, p_comp->flags);
+        p_value->value.val_int = p_comp->val.integer;
+        break;
+
     case CRITERIA_SIZE:
         *p_attr_index = ATTR_INDEX_size;
         *p_compar = Policy2FilterComparator(p_comp->op, p_comp->flags);
@@ -959,6 +965,14 @@ static policy_match_t eval_condition(const entry_id_t *p_entry_id,
             else
                 return bool2policy_match(!rc);
         }
+
+    case CRITERIA_PROJID:
+        /* projid is required */
+        CHECK_ATTR(p_entry_attr, projid, no_warning);
+
+        rc = int_compare(ATTR(p_entry_attr, projid), p_triplet->op,
+                         p_triplet->val.integer);
+        return bool2policy_match(rc);
 
     case CRITERIA_SIZE:
         /* size is required */

--- a/src/policies/policy_run.c
+++ b/src/policies/policy_run.c
@@ -1412,6 +1412,21 @@ static int set_target_filter(const policy_info_t *pol,
                                                    name) ? LIKE : EQUAL,
                                       fval, 0);
 
+#ifdef _LUSTRE
+    case TGT_PROJID:    /* apply policies to the specified projid */
+        DisplayLog(LVL_MAJOR, tag(pol),
+                   "Starting policy run on '%s' project files",
+                   p_param->optarg_u.name);
+
+        attr_mask->std |= ATTR_MASK_projid;
+
+        /* retrieve files for this projid */
+        if (set_projid_val(p_param->optarg_u.name, &fval.value))
+            return EINVAL;
+        return lmgr_simple_filter_add(filter, ATTR_INDEX_projid, EQUAL,
+                                      fval, 0);
+#endif
+
     case TGT_CLASS:    /* apply policies to the specified fileclass */
         DisplayLog(LVL_MAJOR, tag(pol),
                    "Starting policy run on fileclass '%s'",

--- a/src/policies/policy_triggers.c
+++ b/src/policies/policy_triggers.c
@@ -524,6 +524,9 @@ static const char *param2targetstr(const policy_param_t *param, char *str,
     case TGT_POOL:
         snprintf(str, len, "pool %s", param->optarg_u.name);
         return str;
+    case TGT_PROJID:
+        snprintf(str, len, "projid %s", param->optarg_u.name);
+        return str;
 #endif
     case TGT_USER:
         snprintf(str, len, "user %s", param->optarg_u.name);
@@ -920,6 +923,8 @@ static int trig_target_it(target_iterator_t *it, policy_info_t *pol,
         /* check listed pools */
         it->info_u.next_pool_index = 0;
         break;
+    case TGT_PROJID:
+        RBH_BUG("No trigger expected on projid: only for manual actions");
 #endif
     case TGT_USER:
     case TGT_GROUP:
@@ -1066,6 +1071,9 @@ static int trig_target_next(target_iterator_t *it, target_u *tgt,
 #endif
     case TGT_USER:
     case TGT_GROUP:
+#ifdef _LUSTRE
+    case TGT_PROJID:
+#endif
         {
             db_value_t result[2];
             unsigned int result_count = 2;
@@ -1116,6 +1124,9 @@ static void trig_target_end(target_iterator_t *it)
 #endif
     case TGT_USER:
     case TGT_GROUP:
+#ifdef _LUSTRE
+    case TGT_PROJID:
+#endif
         ListMgr_CloseReport(it->info_u.db_report);
         break;
     default:

--- a/src/robinhood/cmd_helpers.c
+++ b/src/robinhood/cmd_helpers.c
@@ -766,6 +766,7 @@ static struct attr_display_spec {
         {ATTR_INDEX_parent_id, "parent_id", 20, 20},
         {ATTR_INDEX_uid,       "user", 10, 10,  print_res_string},
         {ATTR_INDEX_gid,       "group", 10, 10, print_res_string},
+        {ATTR_INDEX_projid,    "projid", 10, 10, print_res_int},
         {ATTR_INDEX_link,      "link", 20, 20},
         {ATTR_INDEX_fileclass, "fileclass", 30, 30, print_res_class},
         /* times */


### PR DESCRIPTION
Add new column projid to table ENTRIES (with default value 0).

Add projid support to scan and changelogs (on CL_CREATE and CL_SETATTR).

Add --split-user-projects/-J option to rbh-report.

Change-Id: If66ba9d21f522830650f428dd846c27052ad89dd