### PR TITLE
Added pipe to head in LVERSION variable line to handle case of multiple lustre-client packages breaking variable

### DIFF
--- a/autotools/m4/lustre.m4
+++ b/autotools/m4/lustre.m4
@@ -13,8 +13,11 @@ AC_DEFUN([AX_LUSTRE_VERSION],
             LPACKAGE=lustre-client
             # Assume we want the same version as this package,
             # whatever 'lustre' or 'lustre-client'
+            # 
+            # Added pipe to `head -1` to properly handle cases of multiple packages; lustre-client and lustre-client-dkms
+            #
             AC_MSG_CHECKING(Lustre version)
-            LVERSION=`rpm -q --whatprovides lustre-client --qf "%{Version}\n" 2>/dev/null | grep -v "no package" | cut -d "." -f 1-2`
+            LVERSION=`rpm -q --whatprovides lustre-client --qf "%{Version}\n" 2>/dev/null | grep -v "no package" | cut -d "." -f 1-2 | head -1`
             AC_MSG_RESULT($LVERSION)
         else
             AC_MSG_RESULT(no)


### PR DESCRIPTION
The command to populate the LVERSION variable in the ./configure script (derived from autotools/m4/lustre.m4) breaks if the build system has more than one lustre-client package installed, such as lustre-client and lustre-client-dkms. If these two packages are installed the command that populates the LVERSION variable breaks as two packages cause a two line result as a variable. Test compilation to validate xattr.h fails and the configure script fails. 

Adding a pipe to `head -1` on the LVERSION (autotools/m4/lustre.m7 line 17) forces a single line output that properly populates the LVERSION variable. 

I don't know that adding `head -1` is the best approach but it works and as robinhood source stands now any build system where the lustre-client and lustre-client-dkms are installed will break.