### PR TITLE
pkg: Add check for php-json

### DIFF
--- a/autotools/m4/phpjson.m4
+++ b/autotools/m4/phpjson.m4
@@ -1,0 +1,17 @@
+#
+# This macro test for php-json (used by webgui)
+#
+AC_DEFUN([AX_PHPJSON_CHECK],
+[
+	chkfile="/usr/lib64/php/modules/json.so"
+
+	AC_CHECK_FILE([$chkfile],
+	[
+	], [
+		AC_MSG_WARN(***********************************************)
+		AC_MSG_WARN(php-json not found under $chkfile)
+		AC_MSG_WARN(webgui will build however it may fail to render)
+		AC_MSG_WARN(graphs yum install php-json?)
+		AC_MSG_WARN(***********************************************)
+	])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,12 @@ AX_ENABLE_FLAG([gprof], [test only: add gprof info to the binaries], [-g -pg])
 AX_ENABLE_FLAG([gcov], [test only: add gcov info to the binaries], [--coverage])
 AX_VALGRIND_CHECK
 
+#
+# Check for php-json
+#
+AX_PHPJSON_CHECK
+
+
 # behavior flags
 AX_DISABLE_FLAG([atfunc], [Don't use 'at' functions for scanning], [-D_NO_AT_FUNC])
 


### PR DESCRIPTION
php-json package is used by webgui. While
the build would pass if php-json package is
missing. It may not render the graphs at all.

This patch adds check for php-json. During the
time of configure. It does not change workflow
or alters functions. If php-json is missing it
will throw an "warning" under config.log so
user can review it post running and add that if
necessary. Hard requirement of php-json was not
selected as not all users would like to use
webgui. Therefore the changes under robinhood.spec.in ("BuildRequires:") was not chosen.

Change-Id: I45c3aeccdd4983a5ae9935dc383b55ced9ffbc5e