### PR TITLE
listmgr: Remove final reference of my_bool

### DIFF
--- a/src/list_mgr/mysql_wrapper.c
+++ b/src/list_mgr/mysql_wrapper.c
@@ -115,7 +115,7 @@ bool db_is_retryable(int db_err)
 /* create client connection */
 int db_connect(db_conn_t *conn)
 {
-    my_bool reconnect = 1;
+    bool reconnect = 1;
     unsigned int retry = 0;
 
     /* Connect to database */


### PR DESCRIPTION
Function db_connect() which has a reference to
data type 'my_pool' was added via commit 2d1de164
on 03 Aug 2010.

Subsequently, via patch 6c174bd2a59d dated 24 Feb 2017 
all "my_bool" defined was replaced via data type bool.

However, the current build is failing with 'unknown type' as
 below under machine configuration show below that.

*** Build error ***
mysql_wrapper.c: In function ‘db_connect’:
error: unknown type name ‘my_bool’; did you mean ‘bool’?
     my_bool reconnect = 1;
*******************

$ gcc --version | grep GCC
gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-18)

$ uname -r
4.18.0-425.3.1.el8_lustre.x86_64

$ cat /etc/rocky-release
Rocky Linux release 8.7 (Green Obsidian)

$ git log --format=oneline -1
509584b63aa2 (origin/master, origin/HEAD, master) \
	policies: implement asc/desc modifier for sort order

This patch replaces _single_ reference to "my_bool" with 
bool making the build pass and looks like type 'my_bool'
 is not used anymore.

Change-Id: I88d8dcdbb49370e8d09d669c523d69a277adc148