### PR TITLE
lustre_tools.c: protect againt IOC_MDC_GETFILEINFO_V1 redefinition

### DIFF
--- a/src/common/lustre_tools.c
+++ b/src/common/lustre_tools.c
@@ -854,7 +854,9 @@ int Get_pool_usage(const char *poolname, struct statfs *pool_statfs)
 #ifdef IOC_MDC_GETFILEINFO_OLD
 #   define IOC_MDC_GETFILEINFO_V1   IOC_MDC_GETFILEINFO_OLD
 #else
+#ifndef IOC_MDC_GETFILEINFO_V1
 #   define IOC_MDC_GETFILEINFO_V1   IOC_MDC_GETFILEINFO
+#endif
 #endif
 
 


### PR DESCRIPTION
With lustre-2.15, IOC_MDC_GETFILEINFO_V1 is already declared in header file.
This patch avoid compilation issue against more recent lustre version.