### PR TITLE
lustre: Correctly identify the IOCTL in case of failure.

### DIFF
--- a/src/common/lustre_tools.c
+++ b/src/common/lustre_tools.c
@@ -871,6 +871,7 @@ int lustre_mds_stat(const char *fullpath, int parentfd, struct stat *inode)
     char buffer[MAXNAMLEN + 1];
     /* always use lov_user_mds_data_v1, as we want a struct stat as output. */
     struct lov_user_mds_data_v1 *lmd = (struct lov_user_mds_data_v1 *)buffer;
+    char *ioctl_name = "IOC_MDC_GETFILEINFO";
     const char *filename;
     int rc;
 
@@ -914,9 +915,12 @@ int lustre_mds_stat(const char *fullpath, int parentfd, struct stat *inode)
         break;
 
     default:
+#ifdef IOC_MDC_GETFILEINFO_OLD
+	ioctl_name = "IOC_MDC_GETFILEINFO_OLD";
+#endif
         DisplayLog(LVL_CRIT, TAG_MDSSTAT,
-                   "Error: %s: IOC_MDC_GETFILEINFO failed for %s: rc=%d, errno=%d",
-                   __func__, fullpath, rc, errno);
+                   "Error: %s: %s failed for %s: rc=%d, errno=%d",
+                   __func__, ioctl_name, fullpath, rc, errno);
     }
     return rc;
 }
@@ -937,6 +941,7 @@ int lustre_mds_stat_by_fid(const entry_id_t *p_id, struct stat *inode)
     char buffer[RBH_PATH_MAX];
     /* always use lov_user_mds_data_v1, as we want a struct stat as output. */
     struct lov_user_mds_data_v1 *lmd = (struct lov_user_mds_data_v1 *)buffer;
+    char *ioctl_name = "IOC_MDC_GETFILEINFO";
     int rc;
 
     /* ensure fid directory is opened */
@@ -978,9 +983,12 @@ int lustre_mds_stat_by_fid(const entry_id_t *p_id, struct stat *inode)
                        __func__, filename);
             return -ENOENT;
         } else {
+#ifdef IOC_MDC_GETFILEINFO_OLD
+	ioctl_name = "IOC_MDC_GETFILEINFO_OLD";
+#endif
             DisplayLog(LVL_CRIT, TAG_MDSSTAT,
-                       "Error: %s: IOC_MDC_GETFILEINFO failed for %s",
-                       __func__, filename);
+                       "Error: %s: %s failed for %s",
+                       __func__, ioctl_name, filename);
             return -errno;
         }
     }


### PR DESCRIPTION
In case of failure returned by IOCTL, under lustre_mds_stat_by_fid() and lustre_mds_stat() the default case was printing the new IOCTL string regardless. This would be incorrect in case OLD IOCTL is called. This patch fixes the above issue, buy rechecking
IOCTL in current use, assigning the correct string then calling DisplayLog() to print the string.

Change-Id: I3d493b75f599aae7b7ba2815451a1ae8f534a282